### PR TITLE
Added system dependant gems for automated testing with Guard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,8 +30,22 @@ group :test do
   gem 'cucumber-rails', '1.2.1', :require => false
   gem 'database_cleaner', '0.7.0'
   # gem 'launchy', '2.1.0'
-  # gem 'rb-fsevent', '0.9.1', :require => false
-  # gem 'growl', '1.0.3'
+ 
+  
+  
+  #if on Macintosh OS X 
+  #gem 'rb-fsevent', '0.9.1', :require => false
+  #gem 'growl', '1.0.3'
+  
+  #if on Linux
+  #gem 'rb-inotify', '0.8.8'
+  #gem 'libnotify', '0.5.9'
+  
+  #if on Windows
+  #gem 'rb-fchange', '0.0.5'
+  #gem 'rb-notifu', '0.0.4'
+  #gem 'win32console', '1.3.0'
+  
 end
 
 group :production do


### PR DESCRIPTION
From the book http://ruby.railstutorial.org/book/ruby-on-rails-tutorial#sec-guard
I thought it would be nice to add these three collection of system dependent gems mentioned in your book.
